### PR TITLE
add resizable naverdict

### DIFF
--- a/src/background/default-dicts.coffee
+++ b/src/background/default-dicts.coffee
@@ -265,5 +265,12 @@ export default [{
     'windowUrlMatch': '[^\\w]query=([^&]+)',
     "resources": {
         styles: ['naver.less']
-    }
+    }, 
+},  {
+        'dictName': 'Naver Korean Resizable', 
+        'windowUrl': 'https://ko.dict.naver.com/search.nhn?query=<word>&target=dic',
+        'windowUrlMatch': '[^\\w]query=([^&]+)',
+        'resources': {
+            styles: ['naver-resizable.less']
+    },
 }]

--- a/src/content/css/naver-resizable.less
+++ b/src/content/css/naver-resizable.less
@@ -1,0 +1,19 @@
+div#header, div#footer, div#aside, div.component_socialplugin, div.tab_scroll_inner, div.section_suggestion{
+    display: none;
+}
+
+div#container {
+    padding: 5px;
+}
+
+div#content {
+    padding: 0px;
+}
+
+div#container, div#content {
+    width: auto;
+}
+
+div.search_area {
+    min-width: 0px;
+}


### PR DESCRIPTION
This adds the Korean dictionary Naver again, but improves on the version that's currently there. I got rid of the sidebar which wasn't useful and made it window resizable. Now it can get as small as you like, as in this picture:

![image](https://user-images.githubusercontent.com/83034407/168446424-8f4aeba7-6799-4ba5-8e6f-95566af439ca.png)

Before, if you made the window this small, things would just get cut off at the end, like this:

![image](https://user-images.githubusercontent.com/83034407/168446482-d6cc1852-7189-4cdc-bf25-8888aaebe174.png)
