### PR TITLE
add margins to dictionary window

### DIFF
--- a/src/content/dictheader.less
+++ b/src/content/dictheader.less
@@ -6,6 +6,8 @@
     background-color: rgba(248, 250, 251, 0.75);
 
     margin-bottom: 0;
+    margin-left: 10px;
+    margin-right: 10px;
     padding-bottom: 0;
     z-index: 9000000304;
 


### PR DESCRIPTION
This adds a bit of margin to the dictionary window style. Before, the buttons on the edge of the screen have no space which looks strange:

![image](https://user-images.githubusercontent.com/83034407/168446621-c978ee70-8365-4770-acdd-7a87e0ba5c9b.png)

After adding a bit of margin, it looks better:

![image](https://user-images.githubusercontent.com/83034407/168446637-4d747886-f23b-4222-85d4-12c622bdfe9d.png)

