### PR TITLE
Naver popup dict

### DIFF
--- a/src/background/lookup-parser.coffee
+++ b/src/background/lookup-parser.coffee
@@ -369,13 +369,13 @@ test = () ->
     # parser.parse('請う').then console.log 
     # parser.parse('あなた').then console.log 
     # parser.parse('장소').then console.log 
-    parser.parse('배').then console.log # this example is here because 배 has a lot of different definitions
+    # parser.parse('배').then console.log # this example is here because 배 has a lot of different definitions
     # parser.parse('бештар').then console.log 
     # parser.parse('бо').then console.log 
     # parser.parse('ไทย').then console.log 
-    # parser.parse('elephant').then console.log 
+    parser.parse('elephant').then console.log 
 
-test()
+# test()
 
 export default {
     parser: new LookupParser(parsers),

--- a/src/background/lookup-parser.coffee
+++ b/src/background/lookup-parser.coffee
@@ -82,11 +82,13 @@ class LookupParser
         )
 
     parse: (w, tname, prevResult) ->
+        console.log "STARTED PARSING WORD #{w}"
         tname ?= @checkType(w)
         return unless tname 
 
         dictDesc = @data[tname]
         url = dictDesc.url.replace('<word>', w)
+        console.log "USING URL #{url}"
 
         # special handle Chinese
         if tname == 'google' 
@@ -103,6 +105,8 @@ class LookupParser
             console.error "Failed to parse: ", url, err 
             return  
 
+
+        console.log "GOT HTML #{JSON.stringify(html)}"
         result = @parseResult html, dictDesc.result
 
         # special handle of bing when look up Chinese
@@ -194,12 +198,16 @@ class LookupParser
 
 
     parseResult: ($el, obj) ->
+        console.log "STARTED PARSING RESULT OF OBJ: #{JSON.stringify(obj)}"
+        console.log "$el is: #{JSON.stringify($el)}"
         result = {}
         for key, desc of obj
             if Array.isArray desc 
+                console.log "IS ARRAY!"
                 result[key] = []
                 result[key].push @parseResult($el, subObj) for subObj in desc
             else 
+                console.log "NOT ARRAY"
                 $container = $el 
                 if desc.container 
                     $container = $($el.find(desc.container).get(0))
@@ -249,6 +257,7 @@ class LookupParser
                         
                 else
                     value = @parseResultItem $container, desc
+                    console.log "PARSERESULT VALUE IS: #{value}"
 
                     if value and key == 'pos'
                         value = trimWordPos value 
@@ -258,6 +267,7 @@ class LookupParser
         return result 
 
     parseResultItem: ($node, desc) ->
+        console.log "PARSING RESULT ITEM"
         value = null
 
         $el = $node 
@@ -312,13 +322,13 @@ test = () ->
     # parser.parse('請').then console.log 
     # parser.parse('請う').then console.log 
     # parser.parse('あなた').then console.log 
-    # parser.parse('장소').then console.log 
+    parser.parse('장소').then console.log 
     # parser.parse('бештар').then console.log 
     # parser.parse('бо').then console.log 
     # parser.parse('ไทย').then console.log 
-    parser.parse('elephant').then console.log 
+    # parser.parse('elephant').then console.log 
 
-# test()
+test()
 
 export default {
     parser: new LookupParser(parsers),

--- a/src/background/lookup-parser.coffee
+++ b/src/background/lookup-parser.coffee
@@ -396,7 +396,6 @@ export default {
             return @checkTypeOfSupport(w)
 
         message.on 'look up plain', ({w, s, sc, sentence}) =>
-            console.log "LOOKING UP PLAIN"
             w = w.trim().toLowerCase()
             return unless w
 

--- a/src/background/lookup-parser.coffee
+++ b/src/background/lookup-parser.coffee
@@ -104,7 +104,7 @@ class LookupParser
                 url = url.replace 'hl=en-US', 'hl='+setting.getValue('otherLang')
 
         try
-            if dictDesc.responseFormat == "json"
+            if dictDesc.name == "naver-dict-json-api"
                 json = await @loadJson url, dictDesc.credentials
             else
                 html = await @load url, dictDesc.credentials

--- a/src/background/setting.coffee
+++ b/src/background/setting.coffee
@@ -29,11 +29,13 @@ export default {
             selectionSK1: 'Shift'
 
             enableLookupEnglish: true,
+            enableLookupKorean: true,
             enableLookupChinese: true,
             otherDisabledLanguages: [],
 
             enablePlainLookup: true,
             englishLookupSource: 'google', # google, bing, wiktionary
+            koreanLookupSource: 'google', # google, naver, wiktionary
             enableAmeAudio: false,
             enableBreAudio: false,
             enableUSUKPron: false,

--- a/src/option/option.coffee
+++ b/src/option/option.coffee
@@ -38,6 +38,11 @@ dictApp.controller 'optionCtrl', ['$scope', ($scope) ->
         'bing': 'Bing Dict',
         'wiktionary': 'Wiktionary'
     };
+    $scope.koreanLookupSources = {
+        'google': 'Google Dict',
+        'wiktionary': 'Wiktionary',
+        'naver': 'Naver Dict',
+    }
     $scope.otherLangs = {
         'zh-CN': 'Chinese',
         "ja-JP": 'Japanese',

--- a/src/options.html
+++ b/src/options.html
@@ -300,6 +300,46 @@
 								<label>
 									<input
 										type="checkbox"
+										ng-model="setting.enableLookupKorean"
+										ng-click="changeKey(!setting.enableLookupKorean, 'enableLookupKorean')"
+									/>
+									Look up <strong>Korean</strong> words
+								</label>
+							</div>
+
+							<div class="indent">
+								<label>
+									Lookup source from:
+								</label>
+
+								<div class="btn-group" uib-dropdown uib-keyboard-nav>
+									<button
+										uib-dropdown-toggle
+										class="form-control btn dropdown-toggle btn-default"
+										type="button"
+										id="btn-koreanLookupSource"
+									>
+										{{ koreanLookupSources[setting.koreanLookupSource] }}
+										<span class="caret"></span>
+									</button>
+	
+									<ul
+										uib-dropdown-menu
+										class="dropdown-menu"
+										role="menu"
+										aria-labelledby="btn-koreanLookupSource"
+									>
+										<li role="menuitem" ng-repeat="(k, v) in koreanLookupSources">
+											<a ng-click="changeKey(k, 'koreanLookupSource')">{{ v }}</a>
+										</li>
+									</ul>
+								</div>
+							</div>
+
+							<div class="checkbox">
+								<label>
+									<input
+										type="checkbox"
 										ng-model="setting.enableLookupEnglish"
 										ng-click="changeKey(!setting.enableLookupEnglish, 'enableLookupEnglish')"
 									/>

--- a/src/resources/dict-parsers.json
+++ b/src/resources/dict-parsers.json
@@ -95,6 +95,7 @@
           }
         }
       },
+
       "defs2": {
         "groups": "[data-tae]>[data-mh='-1']",
         "result": {

--- a/src/resources/dict-parsers.json
+++ b/src/resources/dict-parsers.json
@@ -60,14 +60,9 @@
     }
   },
   "naver": {
-    "url": "https://ko.dict.naver.com/search.nhn?query=<word>&target=dic",
-    "credentials": "same-origin",
+    "url": "https://ko.dict.naver.com/api3/koko/search?query=<word>&m=pc&range=all&lang=ko",
     "languages": ["Korean"],
-    "result": {
-      "w": {
-        "selector": "class='highlight'"
-      }
-    }
+    "name": "naver-dict-json-api"
   },
   "google": {
     "url": "https://www.google.com/search?hl=en-US&q=define+<word>",

--- a/src/resources/dict-parsers.json
+++ b/src/resources/dict-parsers.json
@@ -59,6 +59,16 @@
       }
     }
   },
+  "naver": {
+    "url": "https://ko.dict.naver.com/search.nhn?query=<word>&target=dic",
+    "credentials": "same-origin",
+    "languages": ["Korean"],
+    "result": {
+      "w": {
+        "selector": "class='highlight'"
+      }
+    }
+  },
   "google": {
     "url": "https://www.google.com/search?hl=en-US&q=define+<word>",
     "languages": ["German", "Spanish", "French", "Italian", "Korean"],
@@ -92,7 +102,6 @@
           }
         }
       },
-
       "defs2": {
         "groups": "[data-tae]>[data-mh='-1']",
         "result": {

--- a/src/resources/dict-parsers.json
+++ b/src/resources/dict-parsers.json
@@ -60,13 +60,11 @@
     }
   },
   "naver": {
-    "url": "https://ko.dict.naver.com/api3/koko/search?query=<word>&m=pc&range=all&lang=ko",
-    "languages": ["Korean"],
-    "name": "naver-dict-json-api"
+    "url": "https://ko.dict.naver.com/api3/koko/search?query=<word>&m=pc&range=all&lang=ko"
   },
   "google": {
     "url": "https://www.google.com/search?hl=en-US&q=define+<word>",
-    "languages": ["German", "Spanish", "French", "Italian", "Korean"],
+    "languages": ["German", "Spanish", "French", "Italian"],
     "result": {
       "w": {
         "selector": "[data-dobid='hdw']"
@@ -128,7 +126,6 @@
       "Spanish",
       "French",
       "Italian",
-      "Korean",
       "Portuguese",
       "Swedish",
       "Norwegian",

--- a/src/utils.coffee
+++ b/src/utils.coffee
@@ -117,6 +117,10 @@ export default {
         REGEX_ENG = /[a-zA-Z\s-]+[’'.]?[a-zA-Z\s-]+/
         return str.match(REGEX_ENG)?[0] == str
 
+    hasKorean: (str)->
+        REGEX_KOR = /[\uac00-\ud7af]|[\u1100-\u11ff]|[\u3130-\u318f]|[\ua960-\ua97f]|[\ud7b0-\ud7ff]/g
+        REGEX_KOR.test(str)
+
     isLinux: () -> 
         return window.navigator.platform.includes('Linux')
 


### PR DESCRIPTION
I added the naver korean dictionary as a popup dictionary. Here is what it looks like:

![image](https://user-images.githubusercontent.com/83034407/168448410-2102c247-eb97-4988-b931-fe7e266223dc.png)

The existing google and wiktionary search can't handle scenarios like the above, where a word is conjugated. Since I've only added a Korean version, I added a setting to choose which dictionary should be used, with the default being google.

![image](https://user-images.githubusercontent.com/83034407/168448446-15b0e38d-d616-41f9-927d-c409de8fc417.png)

I might also add the English version of naver dictionary later, and make the popup dictionary look a bit nicer.