### PR TITLE
feat: Ukrainian language support (detection, Wiktionary parsing, TTS)

### DIFF
--- a/src/background/default-dicts.coffee
+++ b/src/background/default-dicts.coffee
@@ -65,6 +65,9 @@ export default [{
   "windowUrl": "https://www.google.com/search?tbm=isch&q=<word>",
   "css": "c-wiz[jsdata='deferred-i3']>div:first-child {display: none;} body {margin-top: 50px !important;}"
 }, {
+    'dictName': 'Slovnyk.ua (Ukrainian)'
+    'windowUrl': 'https://slovnyk.ua/index.php?swrd=<word>'
+}, {
     "dictName": "Captionz (examples on YouTube)",
     "windowUrl": "https://pnl.dev/captionz-ii/?NO_REDIRECT=true",
     "inputSelector": ".search-container input.text-search"

--- a/src/background/default-dicts.coffee
+++ b/src/background/default-dicts.coffee
@@ -65,9 +65,6 @@ export default [{
   "windowUrl": "https://www.google.com/search?tbm=isch&q=<word>",
   "css": "c-wiz[jsdata='deferred-i3']>div:first-child {display: none;} body {margin-top: 50px !important;}"
 }, {
-    'dictName': 'Slovnyk.ua (Ukrainian)'
-    'windowUrl': 'https://slovnyk.ua/index.php?swrd=<word>'
-}, {
     "dictName": "Captionz (examples on YouTube)",
     "windowUrl": "https://pnl.dev/captionz-ii/?NO_REDIRECT=true",
     "inputSelector": ".search-container input.text-search"

--- a/src/background/plain-lookup.coffee
+++ b/src/background/plain-lookup.coffee
@@ -153,6 +153,9 @@ export default {
                 else if (not url.includes('de.wiktionary.org')) \
                     and possibleLangs.includes('German')
                     return @parse(tabId, w, 'wiktionary', prevResult, url.replace(/\w+.wiktionary.org/, 'de.wiktionary.org'))
+                else if (not url.includes('uk.wiktionary.org')) \
+                    and possibleLangs.includes('Ukrainian')
+                    return @parse(tabId, w, 'wiktionary', prevResult, url.replace(/\w+.wiktionary.org/, 'uk.wiktionary.org'))
                 else if possibleLangs.includes('Tajik')
                     return @parseOtherLang tabId, w, 'Tajik', null, prevResult
                 else if possibleLangs.includes('Indonesian')
@@ -228,6 +231,10 @@ export default {
                     
                     if targetLang.lang == 'Svenska'
                         targetLang.lang = 'Swedish'
+                    
+                    # Map Ukrainian heading on uk.wiktionary to English name
+                    if targetLang.lang == 'Українська' or targetLang.lang == 'українська'
+                        targetLang.lang = 'Ukrainian'
 
                     if @isLangDisabled(targetLang.lang) or not langs[targetLang.lang]
                         targetLang = null 

--- a/src/resources/dict-parsers.json
+++ b/src/resources/dict-parsers.json
@@ -143,7 +143,8 @@
       "Vietnamese",
       "Indonesian",
       "Korean",
-      "Thai"
+      "Thai",
+      "Ukrainian"
     ],
     "result": {
       "w": {

--- a/src/resources/langs.json
+++ b/src/resources/langs.json
@@ -88,5 +88,10 @@
     "regex": "[a-zA-Z ]",
     "symbol": "id",
     "synthesis": "id-ID"
+  },
+  "Ukrainian": {
+    "regex": "[а-щьюяґєіїА-ЩЬЮЯҐЄІЇʼ’' ]",
+    "symbol": "uk",
+    "synthesis": "uk-UA"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -250,6 +250,13 @@ var options = {
       cache: false,
     }),
   ],
+  ignoreWarnings: [
+    {
+      module: /node_modules[\\\/]mocha[\\\/]mocha\.js/,
+      message:
+        /Critical dependency: the request of a dependency is an expression/,
+    },
+  ],
   infrastructureLogging: {
     level: "info",
   },


### PR DESCRIPTION
- **Summary**
  - Adds Ukrainian language support across detection, parsing, and speech synthesis.
  - Enables Wiktionary for Ukrainian with smart fallback to `uk.wiktionary.org`.
  - Adds an optional window dictionary entry for Slovnyk.ua ⚠️
  - Cleans up build logs by suppressing a noisy mocha warning ❓

- **What’s changed**
  - **Detection**: Added `Ukrainian` to `src/resources/langs.json` with a specific regex, `symbol: "uk"`, and `synthesis: "uk-UA"`.
  - **Parsing**:
    - Enabled `Ukrainian` in `wiktionary.languages` (`src/resources/dict-parsers.json`).
    - On 404, Wiktionary lookups retry `uk.wiktionary.org`.
    - Maps Wiktionary headings `Українська/українська` to `Ukrainian` for consistent handling (`src/background/plain-lookup.coffee`).
  - **TTS**: Speech synthesis uses `uk-UA` when Ukrainian is detected.
  - **Optional dict**: Added `Slovnyk.ua (Ukrainian)` as a window dictionary (`src/background/default-dicts.coffee`).
  - **Build**: Suppressed mocha dynamic require warning in `webpack.config.js`.